### PR TITLE
fixed displayOrder Bug. Sort parent pages by displayOrder instead of ID.

### DIFF
--- a/controllers/dashboard/composer/list.php
+++ b/controllers/dashboard/composer/list.php
@@ -52,7 +52,8 @@ class DashboardComposerListController extends DashboardBaseController {
         }
 
         if (!$emptyList) {
-            $pl->sortByMultiple('p1.cParentID asc', 'p1.cDisplayOrder asc');
+            $pl->addtoQuery('left join Pages parent ON(p1.cParentID = parent.cID)');
+            $pl->sortByMultiple('parent.cDisplayOrder asc', 'p1.cDisplayOrder asc');
             $pages = $pl->getPage();
         } else {
             $pages = '';


### PR DESCRIPTION
Hat bei Neonet zu flascher Reihenfolge bei der Anzeige der COTM Elemente geführt.:
https://management.mesch.info/mesch-projects/neonet/cotm-2015/fehler-in-toolbox/
Grundsätzlich denke ich ist es wünschenswert wenn die Anzeigereihenfolge der in der Sitemap entspricht, was nach dieser Änderung der Fall ist.
